### PR TITLE
[Feat] 지도 건물 조회 - 주소 API 구현

### DIFF
--- a/Back/src/main/java/kdt/advator/common/domain/Apart.java
+++ b/Back/src/main/java/kdt/advator/common/domain/Apart.java
@@ -2,10 +2,12 @@ package kdt.advator.common.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "apart")
 @Getter
+@NoArgsConstructor
 public class Apart {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/Back/src/main/java/kdt/advator/common/domain/Rating.java
+++ b/Back/src/main/java/kdt/advator/common/domain/Rating.java
@@ -1,9 +1,11 @@
 package kdt.advator.common.domain;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity
 @Table(name = "rating")
+@Getter
 public class Rating {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/Back/src/main/java/kdt/advator/common/dto/ApartDTO.java
+++ b/Back/src/main/java/kdt/advator/common/dto/ApartDTO.java
@@ -1,10 +1,15 @@
 package kdt.advator.common.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import kdt.advator.common.domain.Apart;
+import kdt.advator.estimate.domain.Estimate;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Schema(description = "아파트 DTO")
+@NoArgsConstructor
 public class ApartDTO {
     @Schema(description = "아파트 이름", example = "하나세인스톤3차")
     private String apartName;
@@ -26,4 +31,19 @@ public class ApartDTO {
 
     @Schema(description = "평점", example = "S")
     private String rating;
+
+    @Schema(description = "견적 요청 수", example = "10")
+    private Long request;
+
+    @Builder
+    public ApartDTO(Apart apart, Estimate estimate) {
+        this.apartName = apart.getApartName();
+        this.unitPrice = apart.getUnitPrice();
+        this.tvCount = apart.getTvCount();
+        this.totalPrice = apart.getTotalPrice();
+        this.company = apart.getCompany().getName();
+        this.address = apart.getRoadAddress();
+        this.rating = apart.getRating().getName();
+        this.request = estimate.getRequest();
+    }
 }

--- a/Back/src/main/java/kdt/advator/common/repository/ApartRepository.java
+++ b/Back/src/main/java/kdt/advator/common/repository/ApartRepository.java
@@ -3,6 +3,6 @@ package kdt.advator.common.repository;
 import kdt.advator.common.domain.Apart;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ApartRepository extends JpaRepository<Apart, Long> {
+public interface ApartRepository extends JpaRepository<Apart, Long>, ApartRepositoryCustom {
     Apart findByApartName(String name);
 }

--- a/Back/src/main/java/kdt/advator/common/repository/ApartRepositoryCustom.java
+++ b/Back/src/main/java/kdt/advator/common/repository/ApartRepositoryCustom.java
@@ -1,0 +1,9 @@
+package kdt.advator.common.repository;
+
+import kdt.advator.common.domain.Apart;
+
+import java.util.List;
+
+public interface ApartRepositoryCustom {
+    List<Apart> findByConditions(String city, String district, String area, String rating, String company);
+}

--- a/Back/src/main/java/kdt/advator/common/repository/ApartRepositoryImpl.java
+++ b/Back/src/main/java/kdt/advator/common/repository/ApartRepositoryImpl.java
@@ -1,0 +1,80 @@
+package kdt.advator.common.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kdt.advator.common.domain.Apart;
+import kdt.advator.common.domain.QApart;
+import kdt.advator.estimate.domain.QEstimate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class ApartRepositoryImpl implements ApartRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Apart> findByConditions(String city, String district, String area, String rating, String company) {
+        QApart a = QApart.apart;
+        QEstimate e = QEstimate.estimate;
+        BooleanBuilder conditions = new BooleanBuilder();
+
+        if (city != null && !city.isEmpty())
+            conditions.and(roadAddressContains(city));
+
+        if (district != null && !district.isEmpty())
+            conditions.and(roadAddressContains(district));
+
+        if (area != null && !area.isEmpty())
+            conditions.and(roadAddressContains(area));
+
+        if (rating != null && !rating.isEmpty())
+            conditions.and(ratingEquals(rating));
+
+        if (company != null && !company.isEmpty())
+            conditions.and(companyEquals(company));
+
+        var query = queryFactory.selectFrom(a)
+                .where(conditions);
+
+        List<Apart> resultList = query.fetch();
+
+        log.info("list size : {}", resultList.size());
+        return new ArrayList<>(resultList);  // 중복 제거를 위해 Set으로 변환
+    }
+
+    private BooleanBuilder roadAddressContains(String value) {
+        BooleanBuilder roadAddressConditions = new BooleanBuilder();
+        QApart a = QApart.apart;
+
+        roadAddressConditions.and(a.roadAddress.contains(value));
+        return roadAddressConditions;
+    }
+
+    private BooleanBuilder ratingEquals(String rating) {
+        BooleanBuilder ratingConditions = new BooleanBuilder();
+        QApart a = QApart.apart;
+
+        if (rating != null) {
+            ratingConditions.and(a.rating.name.eq(rating));
+        }
+
+        return ratingConditions;
+    }
+
+    private BooleanBuilder companyEquals(String company) {
+        BooleanBuilder companyConditions = new BooleanBuilder();
+        QApart a = QApart.apart;
+
+        if (company != null) {
+            companyConditions.and(a.company.name.eq(company));
+        }
+
+        return companyConditions;
+    }
+}

--- a/Back/src/main/java/kdt/advator/config/QueryDSLConfig.java
+++ b/Back/src/main/java/kdt/advator/config/QueryDSLConfig.java
@@ -1,0 +1,18 @@
+package kdt.advator.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/Back/src/main/java/kdt/advator/estimate/domain/Estimate.java
+++ b/Back/src/main/java/kdt/advator/estimate/domain/Estimate.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.stereotype.Service;
 
 @Entity
 @Table(name = "estimate")
@@ -23,8 +22,8 @@ public class Estimate {
     private Apart apart;
 
     @Builder
-    public Estimate(Apart apart) {
+    public Estimate(Apart apart, Long request) {
         this.apart = apart;
-        this.request = 1L;
+        this.request = request;
     }
 }

--- a/Back/src/main/java/kdt/advator/estimate/dto/AdvertiseReq.java
+++ b/Back/src/main/java/kdt/advator/estimate/dto/AdvertiseReq.java
@@ -3,11 +3,13 @@ package kdt.advator.estimate.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import kdt.advator.common.dto.ApartDTO;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
 @Schema(description = "15초 광고 견적 요청 DTO")
+@NoArgsConstructor
 public class AdvertiseReq {
     @Schema(description = "아파트 목록")
     private List<ApartDTO> apart;

--- a/Back/src/main/java/kdt/advator/inquiry/service/InquiryService.java
+++ b/Back/src/main/java/kdt/advator/inquiry/service/InquiryService.java
@@ -7,12 +7,9 @@ import kdt.advator.ad_company.dto.InquiryDTO;
 import kdt.advator.ad_company.repository.FocusMediaKoreaRepository;
 import kdt.advator.ad_company.repository.KTTownBoardRepository;
 import kdt.advator.ad_company.repository.MediaMidRepository;
+import kdt.advator.common.domain.*;
 import kdt.advator.estimate.domain.Estimate;
 import kdt.advator.estimate.dto.AdvertiseReq;
-import kdt.advator.common.domain.Business;
-import kdt.advator.common.domain.Company;
-import kdt.advator.common.domain.Industry;
-import kdt.advator.common.domain.User;
 import kdt.advator.common.dto.ApartDTO;
 import kdt.advator.common.repository.*;
 import kdt.advator.estimate.repository.EstimateRepository;
@@ -59,6 +56,21 @@ public class InquiryService {
         return user;
     }
 
+//    @Transactional
+//    public boolean saveSplitAdInquiry(AdvertiseReq advertiseReq, User user) {
+//        List<SplitEstimate> estimateList = new ArrayList<>();
+//
+//        for (ApartDTO apartDTO : advertiseReq.getApart()) {
+//            Apart apart = apartRepository.findByApartName(apartDTO.getApartName());
+//            if (apart == null)
+//                return false;
+//
+//            estimateList.add(new SplitEstimate(advertiseReq, apart, user));
+//        }
+//        splitEstimateRepository.saveAll(estimateList);
+//        return true;
+//    }
+//
     @Transactional
     public InquiryDTO saveFullAdInquiry(AdvertiseReq advertiseReq, User user) {
         List<ApartDTO> apartList = advertiseReq.getApart();
@@ -72,6 +84,7 @@ public class InquiryService {
 
         for (ApartDTO apart : apartList) {
             Company company = companyRepository.findByName(apart.getCompany());
+
             if (company.getName().equals(focusAD)) {
                 FocusMediaKorea focusMediaKorea = FocusMediaKorea.builder()
                         .apart(apartRepository.findByApartName(apart.getApartName()))
@@ -122,7 +135,7 @@ public class InquiryService {
             Estimate estimate = estimateRepository.findByApart(apartRepository.findByApartName(apartDTO.getApartName()));
 
             if (estimate == null) {
-                estimate = new Estimate(apartRepository.findByApartName(apartDTO.getApartName()));
+                estimate = new Estimate(apartRepository.findByApartName(apartDTO.getApartName()), 1L);
             }
             else {
                 estimate.setRequest(estimate.getRequest() + 1);

--- a/Back/src/main/java/kdt/advator/search/controller/SearchController.java
+++ b/Back/src/main/java/kdt/advator/search/controller/SearchController.java
@@ -1,0 +1,24 @@
+package kdt.advator.search.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kdt.advator.common.dto.ApartDTO;
+import kdt.advator.search.dto.SearchApartDTO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Tag(name = "Search", description = "건물 조회 API")
+public interface SearchController {
+
+    @Operation(summary = "지도 건물 조회 - 주소 API", description = "주소를 기준으로 지도 상의 건물을 조회하는 API입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "건물 조회에 성공했습니다.", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "204", description = "건물이 존재하지 않습니다.", content = @Content(mediaType = "application/json"))
+    })
+    public ResponseEntity<List<ApartDTO>> getApartsByAddress(@RequestBody SearchApartDTO searchApartDTO);
+}

--- a/Back/src/main/java/kdt/advator/search/controller/SearchControllerImpl.java
+++ b/Back/src/main/java/kdt/advator/search/controller/SearchControllerImpl.java
@@ -1,0 +1,26 @@
+package kdt.advator.search.controller;
+
+import kdt.advator.common.dto.ApartDTO;
+import kdt.advator.search.dto.SearchApartDTO;
+import kdt.advator.search.service.SearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/search")
+@RequiredArgsConstructor
+public class SearchControllerImpl implements SearchController {
+    private final SearchService searchService;
+
+    @PostMapping("/address")
+    public ResponseEntity<List<ApartDTO>> getApartsByAddress(@RequestBody SearchApartDTO searchApartDTO) {
+        List<ApartDTO> apartDTOList = searchService.getApartByAddress(searchApartDTO);
+        if (apartDTOList == null)
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
+        return ResponseEntity.status(HttpStatus.OK).body(apartDTOList);
+    }
+}

--- a/Back/src/main/java/kdt/advator/search/dto/SearchApartDTO.java
+++ b/Back/src/main/java/kdt/advator/search/dto/SearchApartDTO.java
@@ -1,0 +1,26 @@
+package kdt.advator.search.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "지도 건물 조회 - 주소 DTO")
+public class SearchApartDTO {
+    @Schema(description = "시 이름", example = "서울특별시")
+    private String city;
+
+    @Schema(description = "구 이름", example = "강서구")
+    private String district;
+
+    @Schema(description = "동 이름", example = "곰달래로")
+    private String area;
+
+    @Schema(description = "정렬 기준 (low: 저렴한 순, high: 비싼 순)", example = "low")
+    private String sort;
+
+    @Schema(description = "평점 기준", example = "A")
+    private String rating;
+
+    @Schema(description = "광고 업체명", example = "포커스 미디어 코리아")
+    private String company;
+}

--- a/Back/src/main/java/kdt/advator/search/service/SearchService.java
+++ b/Back/src/main/java/kdt/advator/search/service/SearchService.java
@@ -1,0 +1,60 @@
+package kdt.advator.search.service;
+
+import kdt.advator.common.domain.Apart;
+import kdt.advator.common.dto.ApartDTO;
+import kdt.advator.common.repository.ApartRepository;
+import kdt.advator.estimate.domain.Estimate;
+import kdt.advator.estimate.service.EstimateService;
+import kdt.advator.search.dto.SearchApartDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SearchService {
+    private final ApartRepository apartRepository;
+    private final EstimateService estimateService;
+    
+
+    public List<ApartDTO> getApartByAddress(SearchApartDTO searchApartDTO) {
+        List<Apart> apartList = apartRepository.findByConditions(searchApartDTO.getCity(), searchApartDTO.getDistrict(), searchApartDTO.getArea(),
+                searchApartDTO.getRating(), searchApartDTO.getCompany());
+
+        if (apartList.isEmpty())
+            return null;
+
+        List<Estimate> estimateList = estimateService.getEstimateList(apartList);
+        if (estimateList.isEmpty())
+            return null;
+
+        // DTO 리스트 생성 및 정렬
+        return getApartDTOS(searchApartDTO, apartList, estimateList);
+    }
+
+    private List<ApartDTO> getApartDTOS(SearchApartDTO searchApartDTO, List<Apart> apartList, List<Estimate> estimateList) {
+        Comparator<ApartDTO> priceComparator = Comparator.comparing(ApartDTO::getTotalPrice);
+        if ("high".equalsIgnoreCase(searchApartDTO.getSort())) {
+            priceComparator = priceComparator.reversed();
+        }
+
+        return apartList.stream()
+                .map(apart -> ApartDTO.builder()
+                        .apart(apart)
+                        .estimate(findEstimateForApart(apart, estimateList))
+                        .build())
+                .sorted(priceComparator)
+                .toList();
+    }
+
+    private Estimate findEstimateForApart(Apart apart, List<Estimate> estimateList) {
+        return estimateList.stream()
+                .filter(estimate -> estimate.getApart().equals(apart))
+                .findFirst()
+                .orElse(null); // Estimate가 없을 경우 null 반환
+    }
+}


### PR DESCRIPTION
## 지도 건물 조회 - 주소 API

지도 상에서 도로명 주소를 기준으로 아파트 리스트를 조회합니다.
시, 구, 동, 광고 등급, 광고 업체명을 기준으로 아파트를 필터링 할 수 있고, 가격 순으로 정렬이 가능합니다.

QueryDSL을 적용해 동적 쿼리를 적용했습니다.