### PR TITLE
[Feat] 지도 건물 조회 - GPS API

### DIFF
--- a/Back/src/main/java/kdt/advator/common/controller/CommonController.java
+++ b/Back/src/main/java/kdt/advator/common/controller/CommonController.java
@@ -1,0 +1,19 @@
+package kdt.advator.common.controller;
+
+import kdt.advator.common.service.CommonService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/data")
+@RequiredArgsConstructor
+public class CommonController {
+    private final CommonService commonService;
+
+    @PostMapping("/gps")
+    public void saveApartGps() {
+        commonService.saveApartGps();
+    }
+}

--- a/Back/src/main/java/kdt/advator/common/domain/Apart.java
+++ b/Back/src/main/java/kdt/advator/common/domain/Apart.java
@@ -3,10 +3,12 @@ package kdt.advator.common.domain;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "apart")
 @Getter
+@Setter
 @NoArgsConstructor
 public class Apart {
     @Id
@@ -19,6 +21,10 @@ public class Apart {
     private String lotAddress;
     @Column(name = "road_address")
     private String roadAddress;
+    @Column(name = "gps_x")
+    private Double gpsX;
+    @Column(name = "gps_y")
+    private Double gpsY;
     @Column(name = "tv_count")
     private Long tvCount;
     @Column(name = "unit_price")

--- a/Back/src/main/java/kdt/advator/common/repository/ApartRepositoryCustom.java
+++ b/Back/src/main/java/kdt/advator/common/repository/ApartRepositoryCustom.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface ApartRepositoryCustom {
     List<Apart> findByConditions(String city, String district, String area, List<String> rating, List<String> company);
+    List<Apart> findByGpsXAndGpsY(Double gpsX, Double gpsY, List<String> rating, List<String> company);
 }

--- a/Back/src/main/java/kdt/advator/common/repository/ApartRepositoryImpl.java
+++ b/Back/src/main/java/kdt/advator/common/repository/ApartRepositoryImpl.java
@@ -1,10 +1,11 @@
 package kdt.advator.common.repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kdt.advator.common.domain.Apart;
 import kdt.advator.common.domain.QApart;
-import kdt.advator.estimate.domain.QEstimate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
@@ -21,7 +22,6 @@ public class ApartRepositoryImpl implements ApartRepositoryCustom{
     @Override
     public List<Apart> findByConditions(String city, String district, String area, List<String> rating, List<String> company) {
         QApart a = QApart.apart;
-        QEstimate e = QEstimate.estimate;
         BooleanBuilder conditions = new BooleanBuilder();
 
         if (city != null && !city.isEmpty())
@@ -46,6 +46,37 @@ public class ApartRepositoryImpl implements ApartRepositoryCustom{
 
         log.info("list size : {}", resultList.size());
         return new ArrayList<>(resultList);  // 중복 제거를 위해 Set으로 변환
+    }
+
+    @Override
+    public List<Apart> findByGpsXAndGpsY(Double gpsX, Double gpsY, List<String> rating, List<String> company) {
+        QApart a = QApart.apart;
+        // 지구 반경 (km)
+        Double earthRadius = 6371.0;
+        // 고정 반경 값 설정 (1km)
+        Double radius = 2.0;
+
+        // Haversine 공식 구현
+        NumberExpression<Double> distanceExpression = Expressions.numberTemplate(Double.class,
+                "{0} * acos(cos(radians({1})) * cos(radians({2})) * cos(radians({3}) - radians({4})) + sin(radians({1})) * sin(radians({2})))",
+                earthRadius, gpsY, a.gpsY, a.gpsX, gpsX);
+
+        // 조건 빌더 생성
+        BooleanBuilder conditions = new BooleanBuilder();
+        conditions.and(distanceExpression.loe(radius)); // 반경 조건 추가
+
+        if (rating != null && !rating.isEmpty()) {
+            conditions.and(ratingEquals(rating));
+        }
+
+        if (company != null && !company.isEmpty()) {
+            conditions.and(companyEquals(company));
+        }
+
+        // QueryDSL 쿼리
+        return queryFactory.selectFrom(a)
+                .where(conditions)
+                .fetch();
     }
 
     private BooleanBuilder roadAddressContains(String value) {

--- a/Back/src/main/java/kdt/advator/common/service/CommonService.java
+++ b/Back/src/main/java/kdt/advator/common/service/CommonService.java
@@ -1,0 +1,92 @@
+package kdt.advator.common.service;
+
+import kdt.advator.common.domain.Apart;
+import kdt.advator.common.repository.ApartRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.*;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CommonService {
+    private final ApartRepository apartRepository;
+    private final String defaultURL = "https://dapi.kakao.com/v2/local/search/address.json";
+
+    @Value("${kakao.api.key}") // application.yml에 Kakao API 키 저장
+    private String kakaoApiKey;
+
+    @Transactional
+    public void saveApartGps() {
+        List<Apart> apartList = apartRepository.findAll();
+
+        for (Apart apart : apartList) {
+            try {
+                // 1. URL 인코딩 - URL로 사용할 수 없는 문자들 '%XX'의 형태로 변환
+                // (ex) 한글의 address를 한글로 사용하기 때문에 인코딩을 해줘야 함
+                String roadFullAddr = URLEncoder.encode(apart.getRoadAddress(), "UTF-8");
+
+                // 2. 요청 url을 만들기
+                String addr = defaultURL + "?query=" + roadFullAddr;
+
+                // 3. URL 객체 생성
+                URL url = new URL(addr);
+
+                // 4. URL Connection 객체 생성
+                URLConnection conn = url.openConnection();
+
+                // 5. 헤더값 설정해주기
+                conn.setRequestProperty("Authorization", "KakaoAK " + kakaoApiKey);
+
+                // 6. StringBuffer에 값을 넣고 String 형태로 변환하고 jsonString을 return
+                BufferedReader rd = null;
+                rd = new BufferedReader(new InputStreamReader(conn.getInputStream(), "UTF-8"));
+
+                StringBuffer docJson = new StringBuffer();
+                String line;
+
+                while ((line = rd.readLine()) != null) {
+                    docJson.append(line);
+                }
+                rd.close();
+
+                // 6. 응답 JSON 파싱
+                String jsonString = docJson.toString();
+                JSONObject jsonResponse = new JSONObject(jsonString);
+                JSONArray documents = jsonResponse.getJSONArray("documents");
+
+                if (documents.length() > 0) {
+                    JSONObject firstDocument = documents.getJSONObject(0);
+                    double x = firstDocument.getDouble("x");
+                    double y = firstDocument.getDouble("y");
+
+                    // 7. 좌표 업데이트
+                    apart.setGpsX(x);
+                    apart.setGpsY(y);
+                    apartRepository.save(apart);
+                    log.info("Updated GPS for {}: x={}, y={}", apart.getRoadAddress(), x, y);
+                } else {
+                    log.warn("No coordinates found for address: {}", apart.getRoadAddress());
+                }
+
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            } catch (MalformedURLException e) {
+                e.printStackTrace();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/Back/src/main/java/kdt/advator/search/controller/SearchController.java
+++ b/Back/src/main/java/kdt/advator/search/controller/SearchController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kdt.advator.common.dto.ApartDTO;
 import kdt.advator.search.dto.SearchApartDTO;
+import kdt.advator.search.dto.SearchGpsDTO;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -21,4 +22,6 @@ public interface SearchController {
             @ApiResponse(responseCode = "204", description = "건물이 존재하지 않습니다.", content = @Content(mediaType = "application/json"))
     })
     public ResponseEntity<List<ApartDTO>> getApartsByAddress(@RequestBody SearchApartDTO searchApartDTO);
+
+    public ResponseEntity<List<ApartDTO>> getApartsByGps(@RequestBody SearchGpsDTO searchGpsDTO);
 }

--- a/Back/src/main/java/kdt/advator/search/controller/SearchControllerImpl.java
+++ b/Back/src/main/java/kdt/advator/search/controller/SearchControllerImpl.java
@@ -2,6 +2,7 @@ package kdt.advator.search.controller;
 
 import kdt.advator.common.dto.ApartDTO;
 import kdt.advator.search.dto.SearchApartDTO;
+import kdt.advator.search.dto.SearchGpsDTO;
 import kdt.advator.search.service.SearchService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,4 +21,13 @@ public class SearchControllerImpl implements SearchController {
     public ResponseEntity<List<ApartDTO>> getApartsByAddress(@RequestBody SearchApartDTO searchApartDTO) {
         return ResponseEntity.status(HttpStatus.OK).body(searchService.getApartByAddress(searchApartDTO));
     }
+
+    @PostMapping("/gps")
+    public ResponseEntity<List<ApartDTO>> getApartsByGps(@RequestBody SearchGpsDTO searchGpsDTO) {
+        if (searchGpsDTO.getGpsX() == null || searchGpsDTO.getGpsY() == null)
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+
+        return ResponseEntity.status(HttpStatus.OK).body(searchService.getApartByGps(searchGpsDTO));
+    }
+
 }

--- a/Back/src/main/java/kdt/advator/search/dto/SearchGpsDTO.java
+++ b/Back/src/main/java/kdt/advator/search/dto/SearchGpsDTO.java
@@ -1,0 +1,20 @@
+package kdt.advator.search.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class SearchGpsDTO {
+    private Double gpsX;
+    private Double gpsY;
+    @Schema(description = "정렬 기준 (low: 저렴한 순, high: 비싼 순)", example = "low")
+    private String sort;
+
+    @Schema(description = "평점 기준", example = "A")
+    private List<String> rating;
+
+    @Schema(description = "광고 업체명", example = "포커스 미디어 코리아")
+    private List<String> company;
+}

--- a/Back/src/main/java/kdt/advator/search/service/SearchService.java
+++ b/Back/src/main/java/kdt/advator/search/service/SearchService.java
@@ -6,6 +6,7 @@ import kdt.advator.common.repository.ApartRepository;
 import kdt.advator.estimate.domain.Estimate;
 import kdt.advator.estimate.service.EstimateService;
 import kdt.advator.search.dto.SearchApartDTO;
+import kdt.advator.search.dto.SearchGpsDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -58,4 +59,34 @@ public class SearchService {
                 .findFirst()
                 .orElse(null); // Estimate가 없을 경우 null 반환
     }
+
+    public List<ApartDTO> getApartByGps(SearchGpsDTO searchGpsDTO) {
+        List<Apart> apartList = apartRepository.findByGpsXAndGpsY(searchGpsDTO.getGpsX(), searchGpsDTO.getGpsY(), searchGpsDTO.getRating(), searchGpsDTO.getCompany());
+
+        if (apartList.isEmpty())
+            return new ArrayList<>();
+
+        List<Estimate> estimateList = estimateService.getEstimateList(apartList);
+        if (estimateList.isEmpty())
+            return new ArrayList<>();
+
+        // DTO 리스트 생성 및 정렬
+        return getApartDTOByGPS(searchGpsDTO, apartList, estimateList);
+    }
+
+    private List<ApartDTO> getApartDTOByGPS(SearchGpsDTO searchGpsDTO, List<Apart> apartList, List<Estimate> estimateList) {
+        Comparator<ApartDTO> priceComparator = Comparator.comparing(ApartDTO::getTotalPrice);
+        if ("high".equalsIgnoreCase(searchGpsDTO.getSort())) {
+            priceComparator = priceComparator.reversed();
+        }
+
+        return apartList.stream()
+                .map(apart -> ApartDTO.builder()
+                        .apart(apart)
+                        .estimate(findEstimateForApart(apart, estimateList))
+                        .build())
+                .sorted(priceComparator)
+                .toList();
+    }
+
 }


### PR DESCRIPTION
## 지도 건물 조회 - GPS API
1. 카카오 API를 호출해 Apart DB에 gps 값을 추가했습니다.
2. QueryDSL을 통해 gps, rating, company를 조건으로 아파트를 필터링했습니다.
3. sort를 기준으로 ApartDTO를 정렬해 리턴합니다.